### PR TITLE
Added plugin error messages filter

### DIFF
--- a/wp-ffpc-class.php
+++ b/wp-ffpc-class.php
@@ -251,8 +251,11 @@ class WP_FFPC extends PluginAbstract {
 			}
 		}
 
-		foreach ( $this->errors as $e => $msg ) {
-			$this->utils->alert ( $msg, LOG_WARNING, $this->network );
+		$filtered_errors = apply_filters('wp_ffpc_post_init_errors_array', $this->errors);
+		if ($filtered_errors) {
+			foreach ( $this->errors as $e => $msg ) {
+				$this->utils->alert ( $msg, LOG_WARNING, $this->network );
+			}
 		}
 	}
 


### PR DESCRIPTION
In one of previous changes plugin started creating lots of warning messages (also to log file) regarding cache configuration not being writable (deliberate choice in our production deployment). Filtering errors array before printing allows external plugins/themes to intercept these messages and handle or discard them.