### PR TITLE
Remove PHP closing tag from advanced-cache.php

### DIFF
--- a/wp-ffpc-class.php
+++ b/wp-ffpc-class.php
@@ -971,7 +971,6 @@ class WP_FFPC extends PluginAbstract {
 		$string[] = self::global_config_var . ' = ' . var_export ( $this->global_config, true ) . ';' ;
 		//$string[] = "include_once ('" . $this->acache_backend . "');";
 		$string[] = "include_once ('" . $this->acache_worker . "');";
-		$string[] = "?>";
 
 		/* write the file and start caching from this point */
 		return file_put_contents( $this->acache, join( "\n" , $string ) );


### PR DESCRIPTION
> If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file.
> http://php.net/manual/en/language.basic-syntax.phptags.php
