### PR TITLE
Add composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "petermolnar/wp-ffpc",
+  "type": "wordpress-plugin",
+  "homepage": "https://github.com/petermolnar/wp-ffpc",
+  "license": "GPLv3",
+  "description": "WordPress Plugin WP-FFPC",
+  "keywords": ["plugin", "cache", "page cache", "full page cache", "nginx", "memcached", "apc", "speed"],
+  "require": {
+    "composer/installers": "~1.0.0"
+  }
+}


### PR DESCRIPTION
It would be great if we could make this package composer deployable. I added a basic composer.json here, but also it would be good if your `wp-common` package is moved from a submodule to another plugin (or include them in this repo directly).

Thanks