### PR TITLE
Disable New Relic at AMP in wp-ffpc-acache.php

### DIFF
--- a/wp-ffpc-acache.php
+++ b/wp-ffpc-acache.php
@@ -41,6 +41,13 @@ if (!isset($wp_ffpc_config)) {
 /* request uri */
 $wp_ffpc_uri = $_SERVER['REQUEST_URI'];
 
+/* disable New Relic at AMP */
+if (stripos($wp_ffpc_uri, '/amp/')) {
+    if (extension_loaded('newrelic')) {
+        newrelic_disable_autorum();
+    }
+}
+
 /* no cache for robots.txt */
 if ( stripos($wp_ffpc_uri, 'robots.txt') ) {
 	__wp_ffpc_debug__ ( 'Skippings robots.txt hit');


### PR DESCRIPTION
Prevent New Relic from inserting JS code into an Accelerated Mobile Pages (AMP). This is required to get valid AMP code.

References:
https://www.ampproject.org with https://wordpress.org/plugins/amp/
http://newrelic.com


Background: 
Before this patch, I've written a plugin to disable New Relic at AMP. The problem with that approach is that it will work only for pages that are not cached. I have not found a hook that is "earlier" so I came up with this patch. I think it might help others, too who ran AMP and New Relic and wp-ffpc. 

If there is a better approach, please let me know. Maybe there is a hook that can be used before the cache(?) to get away with the plugin-approach that I've tried in the first place. On the other hand: Why should we ran another plugin, when it can be solved here.
