### PR TITLE
Allow unique release version as part of key scheme

### DIFF
--- a/wp-ffpc-backend.php
+++ b/wp-ffpc-backend.php
@@ -44,6 +44,7 @@ abstract class WP_FFPC_Backend {
 		$ruri = isset ( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 		$rhost = isset ( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : '';
 		$scookie = isset ( $_COOKIE['PHPSESSID'] ) ? $_COOKIE['PHPSESSID'] : '';
+		$release = defined('WP_RELEASE') ? WP_RELEASE : '';
 
 		if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' )
 			$_SERVER['HTTPS'] = 'on';
@@ -56,6 +57,7 @@ abstract class WP_FFPC_Backend {
 			'$request_uri' => $ruri,
 			'$remote_user' => $ruser,
 			'$cookie_PHPSESSID' => $scookie,
+			'$release' => $release
 		);
 
 		/* split single line hosts entry */

--- a/wp-ffpc-class.php
+++ b/wp-ffpc-class.php
@@ -162,6 +162,7 @@ class WP_FFPC extends WP_FFPC_ABSTRACT {
 			'$remote_user' => __('Name of user, authenticated by the Auth Basic Module', 'wp-ffpc'),
 			'$cookie_PHPSESSID' => __('PHP Session Cookie ID, if set ( empty if not )', 'wp-ffpc'),
 			'$accept_lang' => __('First HTTP Accept Lang set in the HTTP request', 'wp-ffpc'),
+			'$release' => __('A unique release number. You can set this dynamically to invalidate cache on new releases by setting the following in wp-config.php (or another included file): <pre>define("WP_RELEASE", "1.0");</pre>')
 			//'$cookie_COOKnginy IE' => __('Value of COOKIE', 'wp-ffpc'),
 			//'$http_HEADER' => __('Value of HTTP request header HEADER ( lowercase, dashes converted to underscore )', 'wp-ffpc'),
 			//'$query_string' => __('Full request URI after rewrites', 'wp-ffpc'),


### PR DESCRIPTION
![2016-05-24 21_21_38-wp-ffpc options wp stable wordpress](https://cloud.githubusercontent.com/assets/1207507/15516966/86ca1626-21f5-11e6-9cea-cd3509cf4d50.png)


Flushing the entire cache in APC or Memcached is not ideal because multiple sites can reside on same server, and because it can also cause the Object Cache to be cleared if you use the same backend for both.

This pull request allows for the use of the variable `$release` in the "Key scheme" to allow invalidation of WP-FFPC page cache when a new version is deployed.

**Use case**: We want the page cache to be invalidated when a new version of the site is released without having to flush the entire cache backend. 

With this PR, we can add the following to `wp-config.php`:

```php
define("WP_RELEASE", '16bb26116228a6c6090214b091725070d894e5ed');
```

(In this example, `16bb26116228a6c6090214b091725070d894e5ed` is the currently deployed Git hash) 

Then we will set `$release` as part of the key scheme:

```
$release-$scheme://$host$request_uri
```

The raw cache keys will now be:

```
meta-16bb26116228a6c6090214b091725070d894e5ed-http://site.com
data-16bb26116228a6c6090214b091725070d894e5ed-http://site.com
```

If we define `WP_RELEASE` dynamically for each release ( using a deploy system like Deployer or Capistrano) we can gracefully invalidate old cache entries without having to flush the entire cache.