### PR TITLE
Fix authentication autofilling wordpress username/password

### DIFF
--- a/wp-ffpc-class.php
+++ b/wp-ffpc-class.php
@@ -808,7 +808,7 @@ class WP_FFPC extends WP_FFPC_ABSTRACT {
 					<label for="authpass"><?php _e('Authentication: password', 'wp-ffpc'); ?></label>
 				</dt>
 				<dd>
-					<input type="password" autocomplete="off" name="authpass" id="authpass" value="<?php echo $this->options['authpass']; ?>" />
+					<input type="text" autocomplete="off" name="authpass" id="authpass" value="<?php echo $this->options['authpass']; ?>" />
 					<span class="description">
 					<?php _e('Password for authentication with for backends - WARNING, the password will be stored in an unsecure format!', 'wp-ffpc'); ?></span>
 				</dd>


### PR DESCRIPTION
Fixes autofilling of the saved WordPress username/password.

It seems like the autofilling uses some (not so) smart heuristics - even changing the `id` and `name` of the form elements is not enough, simply having two input fields next to each other where one of them is `type="password"` is enough to trigger the autocomplete.

This PR changes the password field to a regular textfield - this has only cosmetical and no security implications since the password is sent along to the browser anyway. However the added cosmetical "niceness" does not make up for having to clear the field every time you want to save the settings. :)